### PR TITLE
Corrected makefile, allocation variable (ncell), and renamed energy r…

### DIFF
--- a/Energy.f90
+++ b/Energy.f90
@@ -1,4 +1,4 @@
-SUBROUTINE Energy(T_surf,q_surf,ncell)
+SUBROUTINE surf_energy(T_surf,q_surf,ncell)
    use Block_Energy
    implicit none
    integer::i,ncell,nd
@@ -34,4 +34,4 @@ SUBROUTINE Energy(T_surf,q_surf,ncell)
 !               Return to Subroutine RIVMOD
 !     ******************************************************
 !
-END Subroutine Energy
+END Subroutine Surf_Energy

--- a/makefile
+++ b/makefile
@@ -15,7 +15,7 @@ reservoir: $(objects)
 	$(f90comp) -o reservoir $(objects)
 Block_Energy.o: Block_Energy.f90
 	$(f90comp) -c Block_Energy.f90
-block_energy.mod: Block_Energy.f90
+block_energy.mod: Block_Energy.o Block_Energy.f90
 	$(f90comp) -c Block_Energy.f90
 Block_Reservoir.o: Block_Reservoir.f90
 	$(f90comp) -c Block_Reservoir.f90

--- a/reservoir.f90
+++ b/reservoir.f90
@@ -41,18 +41,15 @@ integer :: nd,ncell,atm_density,q_surf
 !allocate (temp_epil(nd_total))
 !allocate (temp_hypo(nd_total))
 !allocate (temp_out_tot(nd_total))
-
-
+!
+ ncell = 100
+!
 allocate (dbt(ncell))
 allocate (ea(ncell))
 allocate (q_ns(ncell))
 allocate (q_na(ncell))
 allocate (press(ncell))
 allocate (wind(ncell))
-
-
-
-
 ! -------------------- to read in variables from comman line ---------
 !
 ! Read total number of days to simulate JRY 
@@ -61,7 +58,6 @@ allocate (wind(ncell))
 ! read(*,*) nd_total
 
  nd_total = 22645
- ncell = 1
 
 
 ! Read some parameters
@@ -208,7 +204,7 @@ print *, "trial new"
         press(1) = 0.1*ea(1)          !kPa to mb 
 
 
-     call energy(stream_T_in,q_surf,ncell)
+     call surf_energy(stream_T_in,q_surf,ncell)
      !----------------unit transform---------------------------------
         q_surf = q_surf*4186.8        !kcal/m**2/sec to W/m**2     
 


### PR DESCRIPTION
In response to Yifan's question, I made changes to the makefile, moved the allocation variable, ncell, to a line prior to invoking the allocation, changed the name of subroutine energy to avoid what appeared to be a conflict found by the compiler caused by more than one instance of the variable, energy. I think.
